### PR TITLE
Remove hardcoded tactical fees urls from all envs

### DIFF
--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -2,5 +2,3 @@ vault_env = "preprod"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-
-fee_api_url = "https://preprod.fees-register.reform.hmcts.net:4411"

--- a/infrastructure/saat.tfvars
+++ b/infrastructure/saat.tfvars
@@ -1,5 +1,3 @@
 vault_env = "test"
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-
-fee_api_url = "https://preprod.fees-register.reform.hmcts.net:4411"

--- a/infrastructure/sandbox.tfvars
+++ b/infrastructure/sandbox.tfvars
@@ -1,5 +1,3 @@
 vault_env = "test"
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-
-fee_api_url = "https://test.fees-register.reform.hmcts.net:4431"

--- a/infrastructure/sprod.tfvars
+++ b/infrastructure/sprod.tfvars
@@ -1,5 +1,3 @@
 vault_env = "prod"
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
-
-fee_api_url = "https://test.fees-register.reform.hmcts.net:4431"


### PR DESCRIPTION
Preview and sandbox envs were all still pointing to tactical. We have moved the vast majority of services over to CNP so should start using that.