### PR TITLE
[PREVIEW] Add Root Controller

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/divorce/feepayment/controller/RootController.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/feepayment/controller/RootController.java
@@ -1,0 +1,30 @@
+package uk.gov.hmcts.reform.divorce.feepayment.controller;
+
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import static org.springframework.http.ResponseEntity.ok;
+
+/**
+ * Default endpoints per application.
+ */
+@RestController
+@RequestMapping(path = "/")
+public class RootController {
+
+    /**
+     * Root GET endpoint.
+     *
+     * <p>Azure application service has a hidden feature of making requests to root endpoint when
+     * "Always On" is turned on.
+     * This is the endpoint to deal with that and therefore silence the unnecessary 404s as a response code.
+     *
+     * @return Welcome message from the service.
+     */
+    @GetMapping
+    public ResponseEntity<String> welcome() {
+        return ok("Welcome to Divorce Fees and Payments Service");
+    }
+}

--- a/src/test/java/uk/gov/hmcts/reform/divorce/feepayment/controller/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/feepayment/controller/RootControllerTest.java
@@ -4,21 +4,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
-import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
-import org.springframework.test.context.ContextConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 
-import uk.gov.hmcts.reform.divorce.feepayment.FeesPaymentServiceApplication;
-
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 @RunWith(SpringRunner.class)
-@WebMvcTest(RootController.class)
-@ContextConfiguration(classes = FeesPaymentServiceApplication.class)
+@SpringBootTest
 @AutoConfigureMockMvc
 public class RootControllerTest {
 

--- a/src/test/java/uk/gov/hmcts/reform/divorce/feepayment/controller/RootControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/feepayment/controller/RootControllerTest.java
@@ -1,0 +1,40 @@
+package uk.gov.hmcts.reform.divorce.feepayment.controller;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+
+import uk.gov.hmcts.reform.divorce.feepayment.FeesPaymentServiceApplication;
+
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringRunner.class)
+@WebMvcTest(RootController.class)
+@ContextConfiguration(classes = FeesPaymentServiceApplication.class)
+@AutoConfigureMockMvc
+public class RootControllerTest {
+
+    @Autowired
+    private MockMvc mvc;
+
+    @Test
+    public void getShouldReturn200() throws Exception {
+
+        // given
+        MockHttpServletRequestBuilder getRequest = MockMvcRequestBuilders.get("/");
+
+        // when
+        ResultActions performedGet = mvc.perform(getRequest);
+
+        // then
+        performedGet.andExpect(status().isOk()).andReturn();
+    }
+}


### PR DESCRIPTION
Adds a root controller so that Azure calls to '/' do not return a 404 and pollute appinsights error logs.