### PR TITLE
[PREVIEW] Use lookup endpoint for getting fees

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -55,7 +55,7 @@ variable "fee_api_url" {
 }
 
 variable "fee_api_endpoint" {
-    default = "/fees-register/fees"
+    default = "/fees-register/fees/lookup"
 }
 
 variable "subscription" {}

--- a/src/main/java/uk/gov/hmcts/reform/divorce/feepayment/service/impl/FeePaymentServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/feepayment/service/impl/FeePaymentServiceImpl.java
@@ -18,11 +18,7 @@ import java.util.stream.Stream;
 @Slf4j
 public class FeePaymentServiceImpl implements FeePaymentService {
 
-    private static final String CURRENT_VERSION = "current_version";
-
-    private static final String FLAT_AMOUNT = "flat_amount";
-
-    private static final String AMOUNT = "amount";
+    private static final String AMOUNT = "fee_amount";
 
     private static final String VERSION = "version";
 
@@ -55,12 +51,11 @@ public class FeePaymentServiceImpl implements FeePaymentService {
     }
 
     private Fee extractValue(ObjectNode objectNode) {
-        JsonNode currentVersion = objectNode.path(CURRENT_VERSION);
-        double amount = currentVersion
-                .path(FLAT_AMOUNT).get(AMOUNT).asDouble();
-        int version = currentVersion.path(VERSION).asInt();
+        double amount = objectNode.path(AMOUNT).asDouble();
+        int version = objectNode.path(VERSION).asInt();
         String feeCode = objectNode.path(CODE).asText();
-        String description = currentVersion.path(DESCRIPTION).asText();
+        String description = objectNode.path(DESCRIPTION).asText();
+        
         return Fee.builder()
                 .amount(amount)
                 .version(version)

--- a/src/main/java/uk/gov/hmcts/reform/divorce/feepayment/service/impl/FeePaymentServiceImpl.java
+++ b/src/main/java/uk/gov/hmcts/reform/divorce/feepayment/service/impl/FeePaymentServiceImpl.java
@@ -36,13 +36,10 @@ public class FeePaymentServiceImpl implements FeePaymentService {
     @Autowired
     private RestTemplate restTemplate;
 
-
     @Override
     public Fee getFee(String event) {
 
-        Fee defaultFee = Fee.builder().build();
-
-        log.debug("Getting fee from: ", feeApiUrl);
+        log.debug("Getting fee from: " + feeApiUrl);
 
         URI uri = UriComponentsBuilder.fromHttpUrl(feeApiUrl)
                 .queryParam("channel", "default")
@@ -52,12 +49,9 @@ public class FeePaymentServiceImpl implements FeePaymentService {
                 .queryParam("service", "divorce")
                 .build().toUri();
 
-        ObjectNode[] listOfObjects = restTemplate.getForObject(uri, ObjectNode[].class);
+        ObjectNode feeResponse = restTemplate.getForObject(uri, ObjectNode.class);
 
-        return Stream.of(listOfObjects).findFirst()
-                .map(this::extractValue)
-                .orElse(defaultFee);
-
+        return extractValue(feeResponse);
     }
 
     private Fee extractValue(ObjectNode objectNode) {

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -22,7 +22,7 @@ documentation:
 
 fee:
   api:
-    baseUri: ${FEE_API_URL:http://test-proxy.fees-register.reform.hmcts.net/fees-register/fees}
+    baseUri: ${FEE_API_URL:http://test-proxy.fees-register.reform.hmcts.net/fees-register/fees/lookup}
     health: ${baseUri}/health
 
 spring:

--- a/src/test/java/uk/gov/hmcts/reform/divorce/feepayment/service/FeePaymentServiceTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/divorce/feepayment/service/FeePaymentServiceTest.java
@@ -47,8 +47,8 @@ public class FeePaymentServiceTest {
         ReflectionTestUtils.setField(feePaymentService, FEE_API_FIELD_NAME, FEE_API_URL);
         File file = ResourceUtils.getFile(CLASSPATH_URL_PREFIX + "fee.json");
         ObjectNode objectNode = new ObjectMapper().readValue(file, ObjectNode.class);
-        Mockito.when(restTemplate.getForObject(Mockito.eq(uri), Mockito.eq(ObjectNode[].class)))
-                .thenReturn(new ObjectNode[]{objectNode});
+        Mockito.when(restTemplate.getForObject(Mockito.eq(uri), Mockito.eq(ObjectNode.class)))
+                .thenReturn(objectNode);
     }
 
     public FeePaymentService getFeePaymentService() {
@@ -69,6 +69,6 @@ public class FeePaymentServiceTest {
         assertNotNull(actual);
         assertEquals(expected, actual);
         verify(restTemplate, times(1)).getForObject(Mockito.eq(uri),
-                Mockito.eq(ObjectNode[].class));
+                Mockito.eq(ObjectNode.class));
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -22,7 +22,7 @@ documentation:
 
 fee:
   api:
-    baseUri: ${FEE_API_URL:http://test-proxy.fees-register.reform.hmcts.net/fees-register/fees}
+    baseUri: ${FEE_API_URL:http://test-proxy.fees-register.reform.hmcts.net/fees-register/fees/lookup}
     health: ${baseUri}/health
 
 spring:

--- a/src/test/resources/fee.json
+++ b/src/test/resources/fee.json
@@ -1,55 +1,6 @@
 {
-"code": "FEE0002",
-"fee_type": "fixed",
-"channel_type": {
-"name": "default"
-},
-"event_type": {
-"name": "issue"
-},
-"jurisdiction1": {
-"name": "family"
-},
-"jurisdiction2": {
-"name": "family court"
-},
-"service_type": {
-"name": "divorce"
-},
-"applicant_type": {
-"name": "all"
-},
-"fee_versions": [
-{
-"version": 4,
-"valid_from": "2016-03-21T00:00:00.000+0000",
-"description": "Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.",
-"status": "approved",
-"flat_amount": {
-"amount": 550.00
-},
-"memo_line": "GOV - App for divorce/nullity of marriage or CP",
-"statutory_instrument": "2016 No. 402 (L. 5)",
-"si_ref_id": "1.2",
-"natural_account_code": "4481102159",
-"fee_order_name": "The Civil Proceedings, Family Proceedings and Upper Tribunal Fees (Amendment) Order 2016",
-"direction": "enhanced"
-}
-],
-"current_version": {
-"version": 4,
-"valid_from": "2016-03-21T00:00:00.000+0000",
-"description": "Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.",
-"status": "approved",
-"flat_amount": {
-"amount": 550.00
-},
-"memo_line": "GOV - App for divorce/nullity of marriage or CP",
-"statutory_instrument": "2016 No. 402 (L. 5)",
-"si_ref_id": "1.2",
-"natural_account_code": "4481102159",
-"fee_order_name": "The Civil Proceedings, Family Proceedings and Upper Tribunal Fees (Amendment) Order 2016",
-"direction": "enhanced"
-},
-"unspecified_claim_amount": false
-}
+    "code": "FEE0002",
+    "description": "Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.",
+    "version": 4,
+    "fee_amount": 550
+  }


### PR DESCRIPTION
We are currently using the /fees-register/fees endpoint to retrieve fees. This gives us a list of fees matching the search criteria. However if we are getting a test fee in AAT now for the search criteria we use. Payments team has asked us to use the /fees-register/fees/lookup endpoint instead which will retrieve the current active fee for the criteria.