### PR TITLE
DIV-4835 Fix PMD/checkstyle warnings

### DIFF
--- a/ruleset.xml
+++ b/ruleset.xml
@@ -6,26 +6,24 @@
     <description>
         Ruleset for Fee Payment Service
     </description>
-    <rule ref="rulesets/java/basic.xml"/>
-    <rule ref="rulesets/java/braces.xml"/>
-    <rule ref="rulesets/java/design.xml">
-        <exclude name="UseUtilityClass"/>
-        <exclude name="ConfusingTernary"/>
-    </rule>
-    <rule ref="rulesets/java/empty.xml"/>
-    <rule ref="rulesets/java/imports.xml">
-        <exclude name="TooManyStaticImports"/>
-    </rule>
-    <rule ref="rulesets/java/optimizations.xml">
-        <exclude name="MethodArgumentCouldBeFinal"/>
-        <exclude name="LocalVariableCouldBeFinal"/>
-    </rule>
-    <rule ref="rulesets/java/typeresolution.xml"/>
-    <rule ref="rulesets/java/typeresolution.xml/SignatureDeclareThrowsException">
-        <properties>
-            <property name="IgnoreJUnitCompletely" value="true"/>
-        </properties>
-    </rule>
-    <rule ref="rulesets/java/unnecessary.xml"/>
-    <rule ref="rulesets/java/unusedcode.xml"/>
+  <rule ref="category/java/errorprone.xml"/>
+  <rule ref="category/java/multithreading.xml"/>
+  <rule ref="category/java/bestpractices.xml"/>
+  <rule ref="category/java/codestyle.xml">
+      <exclude name="MethodArgumentCouldBeFinal"/>
+      <exclude name="LocalVariableCouldBeFinal"/>
+      <exclude name="TooManyStaticImports"/>
+      <exclude name="ConfusingTernary"/>
+  </rule>
+  <rule ref="category/java/performance.xml"/>
+  <rule ref="category/java/design.xml">
+      <exclude name="UseUtilityClass"/>
+      <exclude name="LoosePackageCoupling"/>
+  </rule>
+  <rule ref="category/java/design.xml/SignatureDeclareThrowsException">
+      <properties>
+          <property name="IgnoreJUnitCompletely" value="true"/>
+      </properties>
+  </rule>
+  <rule ref="category/java/documentation.xml"/>
 </ruleset>


### PR DESCRIPTION
# Description
Previously the Gradle build would be polluted with hundreds of lines of warnings about migration of rulesets to new files. This change migrates to the new rulesets and also carries over the rule exclusions that we have. This makes the build output far more readable.

Fixes # 
[DIV-4835 Fix PMD/checkstyle warnings](https://tools.hmcts.net/jira/browse/DIV-4835)

## Type of change
Reduce log pollution

# How Has This Been Tested?
Run command 
```bash
./gradlew clean build
```
from project directory and check build output for occurrence of ruleset migration messages.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
