### PR TITLE
Override Spring's management endpoint cache to 30 seconds in AAT/Preview

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -118,7 +118,7 @@ def versions = [
         guava: '27.0.1-jre',
         gradlePitest: '1.3.0',
         hibernate: '6.0.5.Final',
-        jacksonCore: '2.9.5',
+        jacksonCore: '2.9.9',
         javaxValidation: '2.0.0.Final',
         jaywayJsonPath: '2.2.0',
         pitest: '1.3.2',

--- a/build.gradle
+++ b/build.gradle
@@ -167,7 +167,7 @@ dependencies {
     compile group: 'org.apache.commons', name: 'commons-lang3', version: versions.commonsLang3
     compile("org.springframework.boot:spring-boot-devtools")
     compile group: 'org.hibernate', name: 'hibernate-validator', version: versions.hibernate
-    compile('com.fasterxml.jackson.core:jackson-databind:2.9.8') {
+    compile('com.fasterxml.jackson.core:jackson-databind:2.9.9') {
         force = true
     }
     compile group: 'com.google.guava', name: 'guava', version: versions.guava

--- a/charts/div-fps/values.aat.template.yaml
+++ b/charts/div-fps/values.aat.template.yaml
@@ -4,6 +4,7 @@ java:
         ENVIRONMENT_NAME : "aat"
         FEE_API_URL : "http://fees-register-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "dummykey"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-fps/values.aat.template.yaml
+++ b/charts/div-fps/values.aat.template.yaml
@@ -4,7 +4,7 @@ java:
         ENVIRONMENT_NAME : "aat"
         FEE_API_URL : "http://fees-register-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "dummykey"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-fps/values.preview.template.yaml
+++ b/charts/div-fps/values.preview.template.yaml
@@ -4,6 +4,7 @@ java:
         ENVIRONMENT_NAME : "aat"
         FEE_API_URL : "http://fees-register-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "dummykey"
+        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/charts/div-fps/values.preview.template.yaml
+++ b/charts/div-fps/values.preview.template.yaml
@@ -4,7 +4,7 @@ java:
         ENVIRONMENT_NAME : "aat"
         FEE_API_URL : "http://fees-register-api-aat.service.core-compute-aat.internal"
         APPINSIGHTS_INSTRUMENTATIONKEY : "dummykey"
-        MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE: "30000"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
 
     # Don't modify below here
     image: ${IMAGE_NAME}

--- a/infrastructure/aat.tfvars
+++ b/infrastructure/aat.tfvars
@@ -2,3 +2,4 @@ vault_env = "preprod"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
+health_check_ttl = 30000

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,7 +28,7 @@ module "div-fees-and-payment-service" {
     REFORM_SERVICE_NAME = "${var.reform_service_name}"
     REFORM_ENVIRONMENT = "${var.env}"
     FEE_API_URL = "${local.fee_api_url}"
-    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE = "${var.health_check_ttl}"
+    MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE = "${var.health_check_ttl}"
   }
 }
 

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -28,6 +28,7 @@ module "div-fees-and-payment-service" {
     REFORM_SERVICE_NAME = "${var.reform_service_name}"
     REFORM_ENVIRONMENT = "${var.env}"
     FEE_API_URL = "${local.fee_api_url}"
+    MANAGEMENT_ENDPOINT_CACHE_TIME-TO-LIVE = "${var.health_check_ttl}"
   }
 }
 

--- a/infrastructure/preview.tfvars
+++ b/infrastructure/preview.tfvars
@@ -2,3 +2,4 @@ vault_env = "preprod"
 
 logging_level_org_springframework_web = "DEBUG"
 logging_level_uk_gov_hmcts_ccd = "DEBUG"
+health_check_ttl = 30000

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -80,5 +80,5 @@ variable "appinsights_instrumentation_key" {
 
 variable "health_check_ttl" {
     type = "string"
-    value = "4000"
+    value = "5000"
 }

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -77,3 +77,8 @@ variable "appinsights_instrumentation_key" {
   description = "Instrumentation key of the App Insights instance this webapp should use. Module will create own App Insights resource if this is not provided"
   default = ""
 }
+
+variable "health_check_ttl" {
+    type = "string"
+    value = "4000"
+}


### PR DESCRIPTION
# Description

To prevent hammering AAT, as every `/health` call checks _every_ dependent service, generating sometimes ~30 subsequent calls (e.g COS)

Tested locally via
`MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE=60000 ./gradlew clean bootrun`

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
