### PR TITLE
DIV-5762 - use java chart v2.6.0 and reduced duplicated env references

### DIFF
--- a/charts/div-fps/Chart.yaml
+++ b/charts/div-fps/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: Divorce - Fees and Payment Service
 name: div-fps
-version: 1.1.0
+version: 1.2.0

--- a/charts/div-fps/requirements.yaml
+++ b/charts/div-fps/requirements.yaml
@@ -1,4 +1,4 @@
 dependencies:
   - name: java
-    version: ~2.3.1
+    version: ~2.6.0
     repository: "@hmctspublic"

--- a/charts/div-fps/values.aat.template.yaml
+++ b/charts/div-fps/values.aat.template.yaml
@@ -1,8 +1,4 @@
 java:
-    environment:
-        FEE_API_URL : "http://fees-register-api-aat.service.core-compute-aat.internal"
-        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
-
     # Don't modify below here
     image: ${IMAGE_NAME}
     ingressHost: ${SERVICE_FQDN}

--- a/charts/div-fps/values.preview.template.yaml
+++ b/charts/div-fps/values.preview.template.yaml
@@ -1,8 +1,4 @@
 java:
-    environment:
-        FEE_API_URL : "http://fees-register-api-aat.service.core-compute-aat.internal"
-        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"
-
     # Don't modify below here
     image: ${IMAGE_NAME}
     ingressHost: ${SERVICE_FQDN}

--- a/charts/div-fps/values.yaml
+++ b/charts/div-fps/values.yaml
@@ -3,3 +3,4 @@ java:
     ingressHost: "div-fps-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     environment:
         FEE_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-aat.internal"
+        MANAGEMENT_ENDPOINT_HEALTH_CACHE_TIMETOLIVE: "30000"

--- a/charts/div-fps/values.yaml
+++ b/charts/div-fps/values.yaml
@@ -1,5 +1,4 @@
 java:
     applicationPort: 4009
     environment:
-        REFORM_SERVICE_NAME: "fps"
-        REFORM_TEAM: "div"
+        FEE_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-aat.internal"

--- a/charts/div-fps/values.yaml
+++ b/charts/div-fps/values.yaml
@@ -1,4 +1,5 @@
 java:
     applicationPort: 4009
+    ingressHost: "div-fps-{{ .Values.global.environment }}.service.core-compute-{{ .Values.global.environment }}.internal"
     environment:
         FEE_API_URL: "http://fees-register-api-{{ .Values.global.environment }}.service.core-compute-aat.internal"


### PR DESCRIPTION
# Description

Reduced duplicated config values by moving them to values.yaml
And using {{ .Values.global.environment }} placeholder
Also removed unused env variables (if any)

See 
* https://github.com/hmcts/chart-java/pull/61 
* https://hmcts-reform.slack.com/archives/CLE7A3SKV/p1568286603003800

Fixes #DIV-5762

## Type of change

- [x] New feature (non-breaking change which adds functionality)



# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules

