### PR TITLE
Infrastructure-variables

### DIFF
--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -20,10 +20,6 @@ variable "raw_product" {
 
 variable "tenant_id" {}
 
-variable "client_id" {
-    description = "(Required) The object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies. This is usually sourced from environment variables and not normally required to be specified."
-}
-
 variable "jenkins_AAD_objectId" {
     type        = "string"
     description = "(Required) The Azure AD object ID of a user, service principal or security group in the Azure Active Directory tenant for the vault. The object ID must be unique for the list of access policies."


### PR DESCRIPTION
# Description

Removed "client_id" from Infrastructure variables.tf file. It was causing the master pipeline to fail
