### PR TITLE
adding consumer tests for fee register controller

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -20,7 +20,7 @@ def component = "fps"
 def channel = '#div-dev'
 
 withPipeline(type , product, component) {
-
+    env.PACT_BROKER_FULL_URL = 'https://pact-broker.platform.hmcts.net'
     enableAksStagingDeployment()
     disableLegacyDeployment()
 
@@ -39,6 +39,10 @@ withPipeline(type , product, component) {
 
     after('functionalTest:aat') {
         steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+    onMaster()
+    {
+        enablePactAs([AppPipelineDsl.PactRoles.CONSUMER])
     }
 
     onMaster {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -30,6 +30,7 @@ withPipeline(type , product, component) {
 
     before('functionalTest:preview') {
         env.ITEST_ENVIRONMENT = "preview"
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
     }
 
     after('checkout') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -1,4 +1,6 @@
 #!groovy
+import uk.gov.hmcts.contino.AppPipelineDsl
+
 
 properties([
         [

--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -18,8 +18,17 @@ def component = "fps"
 
 withNightlyPipeline(type, product, component) {
     env.TEST_URL = params.URL_TO_TEST
-    
+    env.test_environment = 'aat'
+
+    before('fullFunctionalTest') {
+        env.ITEST_ENVIRONMENT = "aat"
+    }
+    after('fullFunctionalTest') {
+        steps.archiveArtifacts allowEmptyArchive: true, artifacts: '**/site/serenity/**/*'
+    }
+
     env.Rules = params.SecurityRules
+    enableFullFunctionalTest()
     enableMutationTest()
     enableSecurityScan()
 }

--- a/audit.json
+++ b/audit.json
@@ -1,0 +1,10 @@
+{
+  "100000_A Client Error response code was returned by the server_https://div-fps-aat.service.core-compute-aat.internal/v2/api-docs_GET":"ignore",
+  "10036_Server Leaks Version Information via \"Server\" HTTP Response Header Field_https://div-fps-aat.service.core-compute-aat.internal/v2/api-docs_GET":"ignore",
+  "10035_Strict-Transport-Security Header Not Set_https://div-fps-aat.service.core-compute-aat.internal/v2/api-docs_GET": "ignore",
+  "100001_Unexpected Content-Type was returned_https://div-fps-aat.service.core-compute-aat.internal/v2/api-docs_GET": "ignore",
+  "10038_Content Security Policy (CSP) Header Not Set_https://div-fps-aat.service.core-compute-aat.internal/v2/api-docs_GET": "ignore"
+}
+
+
+

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'jacoco'
     id 'info.solidsoft.pitest' version '1.4.6'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-    id 'org.owasp.dependencycheck' version '5.3.0'
+    id 'org.owasp.dependencycheck' version '6.0.1'
     id 'org.sonarqube' version '2.8'
     id 'org.springframework.boot' version '2.2.4.RELEASE'
     id 'au.com.dius.pact' version '4.1.0'

--- a/build.gradle
+++ b/build.gradle
@@ -18,7 +18,7 @@ plugins {
     id 'jacoco'
     id 'info.solidsoft.pitest' version '1.4.6'
     id 'io.spring.dependency-management' version '1.0.9.RELEASE'
-    id 'org.owasp.dependencycheck' version '6.0.2'
+    id 'org.owasp.dependencycheck' version '5.3.0'
     id 'org.sonarqube' version '2.8'
     id 'org.springframework.boot' version '2.2.4.RELEASE'
     id 'au.com.dius.pact' version '4.1.0'
@@ -188,7 +188,7 @@ def versions = [
         tomcat:                                         '9.0.37',
         wiremockVersion:                                '2.25.1',
         unirest:                                        '1.4.9',
-        pact_version:                                   '4.0.10',
+        pact_version:                                   '4.1.9',
 ]
 
 dependencies {
@@ -289,10 +289,10 @@ dependencies {
     contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")
     contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.3.2')
 
-    contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-junit', version: versions.pact_version
-    contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-junit5', version: versions.pact_version
-    contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-java8', version: versions.pact_version
-    compile group: 'au.com.dius', name: 'pact-jvm-consumer', version: versions.pact_version
+    contractTestCompile group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
+    contractTestCompile group: 'au.com.dius.pact.consumer', name: 'java8', version: versions.pact_version
+    contractTestRuntime group: 'au.com.dius.pact.consumer', name: 'junit5', version: versions.pact_version
+    contractTestRuntime group: 'au.com.dius.pact.consumer', name: 'java8', version: versions.pact_version
 
     contractTestCompile sourceSets.main.runtimeClasspath
     contractTestCompile sourceSets.test.runtimeClasspath

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ plugins {
     id 'org.owasp.dependencycheck' version '6.0.2'
     id 'org.sonarqube' version '2.8'
     id 'org.springframework.boot' version '2.2.4.RELEASE'
+    id 'au.com.dius.pact' version '4.1.0'
 }
 
 apply plugin: 'checkstyle'
@@ -66,6 +67,16 @@ sourceSets {
         resources {
             srcDirs = ['src/integrationTest/resources']
         }
+    }
+    contractTest {
+        java {
+            compileClasspath += main.output
+            runtimeClasspath += main.output
+            srcDir file('src/contractTest/java')
+            include "uk/gov/hmcts/reform/divorce/feeandpaymentservice/**"
+
+        }
+        resources.srcDir file('src/contractTest/resources')
     }
 }
 
@@ -176,7 +187,8 @@ def versions = [
         springSecurityRsa:                              '1.0.8.RELEASE',
         tomcat:                                         '9.0.37',
         wiremockVersion:                                '2.25.1',
-        unirest:                                        '1.4.9'
+        unirest:                                        '1.4.9',
+        pact_version:                                   '4.0.10',
 ]
 
 dependencies {
@@ -271,6 +283,19 @@ dependencies {
     testCompile(group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: versions.springBoot) {
         exclude(module: 'commons-logging')
     }
+     //pact contract testing
+
+    contractTestCompile("org.junit.jupiter:junit-jupiter-api:5.3.2")
+    contractTestRuntime("org.junit.jupiter:junit-jupiter-engine:5.3.2")
+    contractTestImplementation('org.junit.jupiter:junit-jupiter-api:5.3.2')
+
+    contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-junit', version: versions.pact_version
+    contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-junit5', version: versions.pact_version
+    contractTestCompile group: 'au.com.dius', name: 'pact-jvm-consumer-java8', version: versions.pact_version
+    compile group: 'au.com.dius', name: 'pact-jvm-consumer', version: versions.pact_version
+
+    contractTestCompile sourceSets.main.runtimeClasspath
+    contractTestCompile sourceSets.test.runtimeClasspath
 }
 
 test {
@@ -287,6 +312,49 @@ task functional(type: Test, description: 'Runs the functional tests', group: 'Ve
     setClasspath(sourceSets.integrationTest.runtimeClasspath)
 
     finalizedBy aggregate
+}
+task contract(type: Test) {
+    group = 'Delivery pipeline'
+    description = 'Pact consumer tests for Fee Register'
+    useJUnitPlatform()
+    testClassesDirs = sourceSets.contractTest.output.classesDirs
+    classpath = sourceSets.contractTest.runtimeClasspath
+    include "uk/gov/hmcts/reform/divorce/feeandpaymentservice/**"
+    systemProperty 'pact.rootDir', "pacts"
+    environment("APPINSIGHTS_INSTRUMENTATIONKEY", "test-key")
+
+}
+//below task for pipeline
+task runAndPublishConsumerPactTests(type: Test){
+    logger.lifecycle("Runs consumer contract tests for Fee register client")
+    testClassesDirs = sourceSets.contractTest.output.classesDirs
+    classpath = sourceSets.contractTest.runtimeClasspath
+
+}
+
+runAndPublishConsumerPactTests.dependsOn contract
+
+runAndPublishConsumerPactTests.finalizedBy pactPublish
+
+project.ext {
+    pactVersion = getCheckedOutGitCommitHash()
+}
+
+def getCheckedOutGitCommitHash() {
+    'git rev-parse --verify --short HEAD'.execute().text.trim()
+}
+
+pact {
+    publish {
+        pactDirectory = 'build/pacts'
+        pactBrokerUrl = System.getProperty("pact.broker.url") ?: 'http://localhost:80'
+        tags = [System.getenv("PACT_BRANCH_NAME") ?: 'Dev']
+        version = project.pactVersion
+    }
+    reports {
+        defaultReports()
+        markdown
+    }
 }
 
 jacocoTestReport {
@@ -333,3 +401,4 @@ run {
         jvmArgs = ['-agentlib:jdwp=transport=dt_socket,server=y,suspend=y,address=5010']
     }
 }
+

--- a/build.gradle
+++ b/build.gradle
@@ -8,7 +8,7 @@ buildscript {
     }
     dependencies {
         classpath("org.springframework.boot:spring-boot-gradle-plugin:${springBootVersion}")
-        classpath("net.serenity-bdd:serenity-gradle-plugin:2.1.6")
+        classpath("net.serenity-bdd:serenity-gradle-plugin:2.1.13")
     }
 }
 
@@ -71,6 +71,7 @@ sourceSets {
 
 configurations {
     integrationTestCompile.extendsFrom testCompile
+    integrationTestImplementation.extendsFrom testImplementation
     integrationTestRuntime.extendsFrom testRuntime
 }
 
@@ -161,8 +162,8 @@ def versions = [
         reformsJavaLogging:                             '5.1.7',
         restAssured:                                    '3.0.3',
         serviceTokenGenerator:                          '2.0.0',
-        serenity:                                       '2.1.2',
-        serenityCucumber:                               '1.9.51',
+        serenity:                                       '2.1.13',
+        serenityCucumber:                               '1.9.50',
         serviceAuthProviderClient:                      '0.6.0',
         sonarPitest:                                    '0.5',
         springBoot:                                     '2.2.4.RELEASE',
@@ -190,11 +191,12 @@ dependencies {
     integrationTestCompile group: 'org.skyscreamer', name:'jsonassert', version: versions.jsonassert
     integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-web'
     integrationTestCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'
-    integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
-    integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-cucumber', version: versions.serenityCucumber
-    integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
-    integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
-    integrationTestCompile group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
+    integrationTestCompile group: 'com.sun.xml.bind', name: 'jaxb-osgi', version: '2.3.3'
+    integrationTestImplementation group: 'net.serenity-bdd', name: 'serenity-core', version: versions.serenity
+    integrationTestImplementation group: 'net.serenity-bdd', name: 'serenity-cucumber', version: versions.serenityCucumber
+    integrationTestImplementation group: 'net.serenity-bdd', name: 'serenity-junit', version: versions.serenity
+    integrationTestImplementation group: 'net.serenity-bdd', name: 'serenity-rest-assured', version: versions.serenity
+    integrationTestImplementation group: 'net.serenity-bdd', name: 'serenity-spring', version: versions.serenity
     integrationTestCompile group: 'uk.gov.hmcts.reform', name:'service-auth-provider-client', version: versions.serviceAuthProviderClient
 
     compile (group: 'commons-beanutils', name: 'commons-beanutils', version: versions.commonsBeanUtils) {

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -28,6 +28,20 @@
         </notes>
         <cve>CVE-2020-5421</cve>
     </suppress>
+    <suppress until="2020-11-30Z">
+        <notes>
+            <![CDATA[file name: tomcat-embed-core-9.0.37.jar]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
+    <suppress until="2020-11-30Z">
+        <notes>
+            <![CDATA[file name: tomcat-embed-websocket-9.0.37.jar]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
     <suppress>
         <notes>
             <![CDATA[file name: netty-codec-http2-4.1.45.Final.jar ]]>
@@ -59,5 +73,15 @@
         <vulnerabilityName>A prototype pollution vulnerability in handlebars is exploitable if an attacker can control the template</vulnerabilityName>
         <vulnerabilityName>Disallow calling helperMissing and blockHelperMissing directly</vulnerabilityName>
         <vulnerabilityName>Prototype pollution</vulnerabilityName>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: jetty-webapp-9.4.25.v20191220.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty\-webapp@.*$</packageUrl>
+        <cpe>cpe:/a:eclipse:jetty</cpe>
+    </suppress>
+    <suppress>
+        <notes><![CDATA[file name: jetty-webapp-9.4.25.v20191220.jar]]></notes>
+        <packageUrl regex="true">^pkg:maven/org\.eclipse\.jetty/jetty*.*$</packageUrl>
+        <cve>CVE-2020-27216</cve>
     </suppress>
 </suppressions>

--- a/dependency-check-suppressions.xml
+++ b/dependency-check-suppressions.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<suppressions
-    xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.1.xsd">
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
     <suppress>
         <notes><![CDATA[
             This appears to be a false-positive as this is only exploitable in
@@ -27,5 +26,19 @@
             <![CDATA[CVE is a browser vulnerability]]>
         </notes>
         <cve>CVE-2020-5421</cve>
+    </suppress>
+    <suppress until="2020-11-30Z">
+        <notes>
+            <![CDATA[file name: tomcat-embed-core-9.0.37.jar]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-core@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
+    </suppress>
+    <suppress until="2020-11-30Z">
+        <notes>
+            <![CDATA[file name: tomcat-embed-websocket-9.0.37.jar]]>
+        </notes>
+        <packageUrl regex="true">^pkg:maven/org\.apache\.tomcat\.embed/tomcat\-embed\-websocket@.*$</packageUrl>
+        <cve>CVE-2020-13943</cve>
     </suppress>
 </suppressions>

--- a/security.sh
+++ b/security.sh
@@ -7,5 +7,5 @@ cat zap.out
 zap-cli --zap-url http://0.0.0.0 -p 1001 report -o /zap/api-report.html -f html
 cp /zap/api-report.html functional-output/
 curl --fail http://0.0.0.0:1001/OTHER/core/other/jsonreport/?formMethod=GET --output report.json
-cp *.* functional-output/
-zap-cli -p 1001 alerts -l High
+cp /zap/api-report.html functional-output/
+zap-cli --zap-url http://0.0.0.0 -p 1001 alerts -l High --exit-code False

--- a/src/contractTest/java/uk/gov/hmcts/reform/divorce/feeandpaymentservice/FeePaymentConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/divorce/feeandpaymentservice/FeePaymentConsumerTest.java
@@ -62,7 +62,7 @@ public class FeePaymentConsumerTest {
 
     @Test
     @PactTestFor(pactMethod = "pettitionIssueFee")
-    public void verifypetitionIssueFeePact(MockServer mockServer) throws IOException, JSONException {
+    public void verifyPetitionIssueFeePact(MockServer mockServer) throws IOException, JSONException {
         HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + PETITION_ISSUE_FEE)
                 .execute().returnResponse();
     }

--- a/src/contractTest/java/uk/gov/hmcts/reform/divorce/feeandpaymentservice/FeePaymentConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/divorce/feeandpaymentservice/FeePaymentConsumerTest.java
@@ -1,0 +1,212 @@
+package uk.gov.hmcts.reform.divorce.feeandpaymentservice;
+
+import au.com.dius.pact.consumer.MockServer;
+import au.com.dius.pact.consumer.dsl.PactDslJsonBody;
+import au.com.dius.pact.consumer.dsl.PactDslWithProvider;
+import au.com.dius.pact.consumer.junit5.PactConsumerTestExt;
+import au.com.dius.pact.consumer.junit5.PactTestFor;
+import au.com.dius.pact.core.model.RequestResponsePact;
+import au.com.dius.pact.core.model.annotations.Pact;
+import au.com.dius.pact.core.model.annotations.PactFolder;
+import org.apache.http.HttpResponse;
+import org.apache.http.client.fluent.Request;
+import org.json.JSONException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.io.IOException;
+
+@ExtendWith(PactConsumerTestExt.class)
+@ExtendWith(SpringExtension.class)
+@PactTestFor(providerName = "feeRegister_lookUp", port = "4009")
+@PactFolder("build/pacts")
+
+public class FeePaymentConsumerTest {
+
+    private static final String BASEURI = "/fees-register/fees/lookup";
+    private static final String PETITION_ISSUE_FEE = "channel=default&event=issue&jurisdiction1=family&"
+            + "jurisdiction2=family%20court&service=divorce";
+    private static final String AMEND_FEE = "channel=default&event=issue&jurisdiction1=family&jurisdiction2=family%20court&service=other&keyword=ABC";
+    private static final String DEFENDENT_FEE = "channel=default&event=issue&jurisdiction1=family&"
+            + "jurisdiction2=family%20court&service=other&keyword=PQR";
+    private static final String GENRALAPPLICATION_FEE = "channel=default&event=general%20application&jurisdiction1=family&"
+            + "jurisdiction2=family%20court&service=other";
+    private static final String ENFORCEMENT_FEE = "channel=default&event=enforcement&jurisdiction1=family&"
+            + "jurisdiction2=family%20court&keyword=HIJ&service=other";
+    private static final String FINANCIALORDER_FEE = "channel=default&event=miscellaneous&jurisdiction1=family&"
+            + "jurisdiction2=family%20court&keyword=financial-order&service=other";
+    private static final String APPLICATION_NO_NOTICE = "channel=default&event=general%20application&jurisdiction1=family&"
+            + "jurisdiction2=family%20court&keyword=GeneralAppWithoutNotice&service=other";
+
+    @BeforeEach
+    public void setUpEachTest() throws InterruptedException {
+        Thread.sleep(2000);
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact pettitionIssueFee(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("request for petition issue fee")
+                .path(BASEURI)
+                .encodedQuery(PETITION_ISSUE_FEE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0002", 550.00, 4,
+                        "Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2."))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "pettitionIssueFee")
+    public void verifypetitionIssueFeePact(MockServer mockServer) throws IOException, JSONException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + PETITION_ISSUE_FEE)
+                .execute().returnResponse();
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact getAmendFee(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("received request for Amend issue fee")
+                .path(BASEURI)
+                .encodedQuery(AMEND_FEE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0233", 95.00, 1,
+                        "Amendment of application for matrimonial/civil partnership orde"))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getAmendFee")
+    public void verifyAmendFeePact(MockServer mockServer) throws IOException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + AMEND_FEE)
+                .execute().returnResponse();
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact getDefendantFee(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("received request for Defendant issue fee")
+                .path(BASEURI)
+                .encodedQuery(DEFENDENT_FEE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0388", 245.00, 1,
+                        "Originating proceedings where no other fee is specified"))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "getDefendantFee")
+    public void verifyDefendantFeePact(MockServer mockServer) throws IOException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + DEFENDENT_FEE)
+                .execute().returnResponse();
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact generalApplicationFee(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("received request for General Application fee")
+                .path(BASEURI)
+                .encodedQuery(GENRALAPPLICATION_FEE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0271", 50.00, 1,
+                        "Application for decree nisi, conditional order, separation order (no fee if undefended"))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "generalApplicationFee")
+    public void verifyGeneralApplicationFeePact(MockServer mockServer) throws IOException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + GENRALAPPLICATION_FEE)
+                .execute().returnResponse();
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact enforcementFee(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("received request for Enforcement Application fee")
+                .path(BASEURI)
+                .encodedQuery(ENFORCEMENT_FEE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0392", 45.00, 2,
+                        "Request for service by a bailiff of document (see order for exceptions)"))
+                .toPact();
+    }
+
+
+    @Test
+    @PactTestFor(pactMethod = "enforcementFee")
+    public void verifyEnforcementFeePact(MockServer mockServer) throws IOException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + ENFORCEMENT_FEE)
+                .execute().returnResponse();
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact financialOrderFee(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("received request for Financial Order Application fee")
+                .path(BASEURI)
+                .encodedQuery(FINANCIALORDER_FEE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0229", 255.00, 1,
+                        "Application for a financial orde"))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "financialOrderFee")
+    public void verifyFinancialOrderFeePact(MockServer mockServer) throws IOException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + FINANCIALORDER_FEE)
+                .execute().returnResponse();
+    }
+
+    @Pact(consumer = "divorce_feeAndPaymentService_feeRegister")
+    public RequestResponsePact applicationNoNotice(PactDslWithProvider builder) {
+
+        return builder.given("service is registered in Fee registry")
+                .uponReceiving("received request for application no notice fee")
+                .path(BASEURI)
+                .encodedQuery(APPLICATION_NO_NOTICE)
+                .method("GET")
+                .willRespondWith()
+                .status(200)
+                .body(getFeeResponseBody("FEE0228", 50.00, 1,
+                        "Application (without notice)"))
+                .toPact();
+    }
+
+    @Test
+    @PactTestFor(pactMethod = "applicationNoNotice")
+    public void verifyApplicationNoNoticeFeePact(MockServer mockServer) throws IOException {
+        HttpResponse httpResponse = Request.Get(mockServer.getUrl() + BASEURI + "?" + APPLICATION_NO_NOTICE)
+                .execute().returnResponse();
+    }
+
+    private PactDslJsonBody getFeeResponseBody(String Code, double amount, int version, String description) {
+        return new PactDslJsonBody()
+                .stringType("code", Code)
+                .decimalType("fee_amount", amount)
+                .numberValue("version", version)
+                .stringType("description", description);
+    }
+}
+
+

--- a/src/contractTest/java/uk/gov/hmcts/reform/divorce/feeandpaymentservice/FeePaymentConsumerTest.java
+++ b/src/contractTest/java/uk/gov/hmcts/reform/divorce/feeandpaymentservice/FeePaymentConsumerTest.java
@@ -200,9 +200,9 @@ public class FeePaymentConsumerTest {
                 .execute().returnResponse();
     }
 
-    private PactDslJsonBody getFeeResponseBody(String Code, double amount, int version, String description) {
+    private PactDslJsonBody getFeeResponseBody(String code, double amount, int version, String description) {
         return new PactDslJsonBody()
-                .stringType("code", Code)
+                .stringType("code", code)
                 .decimalType("fee_amount", amount)
                 .numberValue("version", version)
                 .stringType("description", description);

--- a/src/contractTest/resources/application.yml
+++ b/src/contractTest/resources/application.yml
@@ -1,0 +1,92 @@
+server:
+  port: ${FEES_AND_PAYMENTS_PORT:4009}
+
+http:
+  connect:
+    timeout: 60000
+    request:
+      timeout: 60000
+
+health:
+  check:
+    http:
+      connect:
+        timeout: 5000
+        request:
+          timeout: 5000
+
+info:
+  app:
+    name: ${spring.application.name}
+
+evidence-management-api:
+  service:
+    stub:
+      enabled: false
+
+documentation:
+  swagger:
+    enabled: true
+
+fee:
+  api:
+    baseUri: ${FEE_API_URL:http://fees-register-api-aat.service.core-compute-aat.internal}
+    feesLookup: /fees-register/fees/lookup
+    health: /health
+    genAppWithoutNoticeFeeKeyword: ${GENERAL_APPLICATION_WITHOUT_NOTICE_FEE_KEYWORD:GeneralAppWithoutNotice}
+
+spring:
+  resources:
+    static-locations:
+  application:
+    name: Fees And Payments Service
+
+# GENERAL SPRING BOOT ACTUATOR CONFIG
+# Context path for Spring Boot Actuator endpoints
+# Allow actuator endpoints to be accessed without requiring authentication
+# Enable default health indicators
+# Enable disk space health check
+# HEALTH ENDPOINT CONFIG
+# Enable the health endpoint
+# Enable sensitive health information
+# Defines the URL of the health check to ${management.context-path}/health
+# Caching period in milliseconds of health endpoint
+# METRICS ENDPOINT CONFIG
+# Enable the metrics endpoint
+# Enable sensitive metrics information
+management:
+  server:
+    servlet:
+      context-path: /
+  info:
+    defaults:
+      enabled: true
+    security:
+      enabled: false
+  health:
+    defaults:
+      enabled: true
+    diskspace:
+      enabled: true
+  endpoint:
+    health:
+      show-details: "ALWAYS"
+      enabled: true
+      cache:
+        time-to-live: 5000
+    metrics:
+      enabled: true
+  endpoints:
+    web:
+      base-path: /
+
+
+logging:
+  level:
+    org.springframework.web: ERROR
+    uk.gov.hmcts.reform.divorce.feepayment: DEBUG
+  pattern:
+    console: "%d{yyyy-MMM-dd HH:mm:ss.SSS} %-5level [%thread] %logger{15} - %msg%n"
+
+azure:
+  app_insights_key: ${APPINSIGHTS_INSTRUMENTATIONKEY:false}

--- a/src/integrationTest/java/uk/gov/hmcts/reform/divorce/feepayment/test/FeePaymentIntegrationTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/divorce/feepayment/test/FeePaymentIntegrationTest.java
@@ -2,11 +2,11 @@ package uk.gov.hmcts.reform.divorce.feepayment.test;
 
 import net.serenitybdd.junit.runners.SerenityParameterizedRunner;
 import net.serenitybdd.junit.spring.integration.SpringIntegrationMethodRule;
+import net.thucydides.junit.annotations.TestData;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
 import org.springframework.boot.autoconfigure.http.HttpMessageConvertersAutoConfiguration;
@@ -16,6 +16,9 @@ import org.springframework.cloud.openfeign.ribbon.FeignRibbonClientAutoConfigura
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.test.context.ContextConfiguration;
+
+import java.util.Arrays;
+import java.util.Collection;
 
 import static io.restassured.RestAssured.baseURI;
 import static net.serenitybdd.rest.SerenityRest.when;
@@ -46,25 +49,25 @@ public class FeePaymentIntegrationTest {
         this.feeEndpoint = feeEndpoint;
     }
 
-    @Parameterized.Parameters
-    public static String[]data() {
-        return new String[] {
-            "/petition-issue-fee",
-            "/general-application-fee",
-            "/enforcement-fee",
-            "/application-financial-order-fee",
-            "application-without-notice-fee",
-            "/amend-fee",
-            "/defended-petition-fee"
-        };
+    @TestData
+    public static Collection<Object[]> data() {
+        return Arrays.asList(new Object[][]{
+                {"/petition-issue-fee"},
+                {"/enforcement-fee"},
+                {"/application-financial-order-fee"},
+                {"application-without-notice-fee"},
+                {"/amend-fee"},
+                {"/defended-petition-fee"},
+                {"/general-application-fee"}
+        });
     }
 
     @Test
     public void feeTest() {
         when()
-            .get(feeEndpoint)
-            .then()
-            .assertThat().statusCode(200)
-            .and().body("feeCode", isA(String.class));
+                .get(feeEndpoint)
+                .then()
+                .assertThat().statusCode(200)
+                .and().body("feeCode", isA(String.class));
     }
 }


### PR DESCRIPTION
# Description

Adding Pact consumer tests for fee register app.


# How Has This Been Tested?

https://pact-broker.platform.hmcts.net/hal-browser/browser.html#/pacts/provider/feeRegister_lookUp/consumer/divorce_feeAndPaymentService_feeRegister/pact-version/c016c3c01b9ae3b653586dec97d1e9e9886f632e/verification-results/5390


